### PR TITLE
Fix missing item group translation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,43 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a package using Gradle and then publish it to GitHub packages when a release is created
+# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-gradle
+
+name: Gradle Package
+
+on: [push]
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+          settings-path: ${{ github.workspace }} # location for the settings.xml file
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+
+      - name: Fix Gradle permissions
+        run: chmod +x ./gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Upload Build
+        uses: actions/upload-artifact@v4
+        with:
+          name: Secret Rooms Nightly
+          path: |
+            ${{ github.workspace }}/build/libs/*.jar

--- a/src/main/java/net/mythical/secretrooms/item/ModItemGroup.java
+++ b/src/main/java/net/mythical/secretrooms/item/ModItemGroup.java
@@ -23,7 +23,7 @@ public class ModItemGroup {
     }));
 
     public static ItemGroup register(String id, ItemGroup.Builder itemGroup) {
-        return Registry.register(Registries.ITEM_GROUP, Identifier.of(SecretRooms.MOD_ID, id), itemGroup.displayName(Text.translatable("itemgroup." + SecretRooms.MOD_ID + "." + id.replace("/", "."))).build());
+        return Registry.register(Registries.ITEM_GROUP, Identifier.of(SecretRooms.MOD_ID, id), itemGroup.displayName(Text.translatable("itemGroup." + SecretRooms.MOD_ID + "." + id.replace("/", "."))).build());
     }
     public static void register() {}
 }


### PR DESCRIPTION
The code has incorrect capitalization of itemGroup, which causes the translation to not be picked up correctly.